### PR TITLE
NIFIREG-216 Add S3 Endpoint URL Override

### DIFF
--- a/nifi-registry-core/nifi-registry-docker/dockerhub/DockerImage.txt
+++ b/nifi-registry-core/nifi-registry-docker/dockerhub/DockerImage.txt
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apache/nifi-registry:0.3.0
+apache/nifi-registry:0.4.0

--- a/nifi-registry-core/nifi-registry-docker/dockerhub/README.md
+++ b/nifi-registry-core/nifi-registry-docker/dockerhub/README.md
@@ -42,7 +42,7 @@ The configuration scripts are suitable for at least 0.1.0+.
 
 ## Running a container
 
-### Standalone Instance, Unsecured
+### Unsecured
 The minimum to run a NiFi Registry instance is as follows:
 
     docker run --name nifi-registry \
@@ -63,7 +63,7 @@ You can also pass in environment variables to change the NiFi Registry communica
 
 For a list of the environment variables recognised in this build, look into the .sh/secure.sh and .sh/start.sh scripts
         
-### Standalone Instance, Two-Way SSL
+### Secured with Two-Way TLS
 In this configuration, the user will need to provide certificates and the associated configuration information.
 Of particular note, is the `AUTH` environment variable which is set to `tls`.  Additionally, the user must provide an
 the DN as provided by an accessing client certificate in the `INITIAL_ADMIN_IDENTITY` environment variable.
@@ -84,7 +84,7 @@ Finally, this command makes use of a volume to provide certificates on the host 
       -d \
       apache/nifi-registry:latest
 
-### Standalone Instance, LDAP
+### Secured with LDAP
 In this configuration, the user will need to provide certificates and the associated configuration information.  Optionally,
 if the LDAP provider of interest is operating in LDAPS or START_TLS modes, certificates will additionally be needed.
 Of particular note, is the `AUTH` environment variable which is set to `ldap`.  Additionally, the user must provide a
@@ -92,7 +92,7 @@ DN as provided by the configured LDAP server in the `INITIAL_ADMIN_IDENTITY` env
 used to seed the instance with an initial user with administrative privileges.  Finally, this command makes use of a 
 volume to provide certificates on the host system to the container instance.
 
-#### For a minimal, connection to an LDAP server using SIMPLE authentication:
+For a minimal, connection to an LDAP server using SIMPLE authentication:
 
     docker run --name nifi-registry \
       -v /path/to/tls/certs/localhost:/opt/certs \
@@ -115,7 +115,7 @@ volume to provide certificates on the host system to the container instance.
       -d \
       apache/nifi-registry:latest
 
-#### The following, optional environment variables may be added to the above command when connecting to a secure  LDAP server configured with START_TLS or LDAPS
+The following, optional environment variables may be added to the above command when connecting to a secure LDAP server configured with START_TLS or LDAPS
 
     -e LDAP_TLS_KEYSTORE: ''
     -e LDAP_TLS_KEYSTORE_PASSWORD: ''
@@ -124,7 +124,11 @@ volume to provide certificates on the host system to the container instance.
     -e LDAP_TLS_TRUSTSTORE_PASSWORD: ''
     -e LDAP_TLS_TRUSTSTORE_TYPE: ''
 
-### The following, optional environment variables can be used to configure the database
+### Additional Configuration Options
+
+#### Database Configuration
+
+The following, optional environment variables can be used to configure the database.
 
 | nifi-registry.properties entry         | Variable                   |
 |----------------------------------------|----------------------------|
@@ -136,7 +140,9 @@ volume to provide certificates on the host system to the container instance.
 | nifi.registry.db.maxConnections        | NIFI_REGISTRY_DB_MAX_CONNS |
 | nifi.registry.db.sql.debug             | NIFI_REGISTRY_DB_DEBUG_SQL |
 
-#### The following, optional environment variables may be added to configure flow persistence provider.
+#### Flow Persistence Configuration
+
+The following, optional environment variables may be added to configure flow persistence provider.
 
 | Environment Variable           | Configuration Property               |
 |--------------------------------|--------------------------------------|
@@ -145,4 +151,20 @@ volume to provide certificates on the host system to the container instance.
 | NIFI_REGISTRY_GIT_REMOTE       | Remote to Push                       |
 | NIFI_REGISTRY_GIT_USER         | Remote Access User                   |
 | NIFI_REGISTRY_GIT_PASSWORD     | Remote Access Password               |
+
+#### Extension Bundle Persistence Configuration
+
+The following, optional environment variables may be added to configure extension bundle persistence provider.
+
+| Environment Variable                  | Configuration Property              |
+|---------------------------------------|-------------------------------------|
+| NIFI_REGISTRY_BUNDLE_STORAGE_DIR      | Extension Bundle Storage Directory  |
+| NIFI_REGISTRY_BUNDLE_PROVIDER         | (Class tag); valid values: file, s3 |
+| NIFI_REGISTRY_S3_REGION               | Region                              |
+| NIFI_REGISTRY_S3_BUCKET_NAME          | Bucket Name                         |
+| NIFI_REGISTRY_S3_KEY_PREFIX           | Key Prefix                          |
+| NIFI_REGISTRY_S3_CREDENTIALS_PROVIDER | Credentials Provider                |
+| NIFI_REGISTRY_S3_ACCESS_KEY           | Access Key                          |
+| NIFI_REGISTRY_S3_SECRET_ACCESS_KEY    | Secret Access Key                   |
+| NIFI_REGISTRY_S3_ENDPOINT_URL         | Endpoint URL                        |
 

--- a/nifi-registry-core/nifi-registry-docker/dockerhub/sh/start.sh
+++ b/nifi-registry-core/nifi-registry-docker/dockerhub/sh/start.sh
@@ -43,6 +43,7 @@ case ${AUTH} in
 esac
 
 . "${scripts_dir}/update_flow_provider.sh"
+. "${scripts_dir}/update_bundle_provider.sh"
 
 # Continuously provide logs so that 'docker logs' can produce them
 tail -F "${NIFI_REGISTRY_HOME}/logs/nifi-registry-app.log" &

--- a/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_bundle_provider.sh
+++ b/nifi-registry-core/nifi-registry-docker/dockerhub/sh/update_bundle_provider.sh
@@ -1,0 +1,48 @@
+#!/bin/sh -e
+
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+providers_file=${NIFI_REGISTRY_HOME}/conf/providers.xml
+property_xpath='/providers/extensionBundlePersistenceProvider'
+
+add_property() {
+  property_name=$1
+  property_value=$2
+
+  if [ -n "${property_value}" ]; then
+    xmlstarlet ed --inplace --subnode "${property_xpath}" --type elem -n property -v "${property_value}" \
+      -i \$prev --type attr -n name -v "${property_name}" \
+      "${providers_file}"
+  fi
+}
+
+xmlstarlet ed --inplace -u "${property_xpath}/property[@name='Extension Bundle Storage Directory']" -v "${NIFI_REGISTRY_BUNDLE_STORAGE_DIR:-./extension_bundles}" "${providers_file}"
+
+case ${NIFI_REGISTRY_BUNDLE_PROVIDER} in
+    file)
+        xmlstarlet ed --inplace -u "${property_xpath}/class" -v "org.apache.nifi.registry.provider.extension.FileSystemBundlePersistenceProvider" "${providers_file}"
+        ;;
+    s3)
+        xmlstarlet ed --inplace -u "${property_xpath}/class" -v "org.apache.nifi.registry.aws.S3BundlePersistenceProvider" "${providers_file}"
+        add_property "Region"                "${NIFI_REGISTRY_S3_REGION:-}"
+        add_property "Bucket Name"           "${NIFI_REGISTRY_S3_BUCKET_NAME:-}"
+        add_property "Key Prefix"            "${NIFI_REGISTRY_S3_KEY_PREFIX:-}"
+        add_property "Credentials Provider"  "${NIFI_REGISTRY_S3_CREDENTIALS_PROVIDER:-DEFAULT_CHAIN}"
+        add_property "Access Key"            "${NIFI_REGISTRY_S3_ACCESS_KEY:-}"
+        add_property "Secret Access Key"     "${NIFI_REGISTRY_S3_SECRET_ACCESS_KEY:-}"
+        add_property "Endpoint URL"          "${NIFI_REGISTRY_S3_ENDPOINT_URL:-}"
+        ;;
+esac

--- a/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/providers.xml
+++ b/nifi-registry-core/nifi-registry-resources/src/main/resources/conf/providers.xml
@@ -74,6 +74,8 @@
                 - STATIC requires that "Access Key" and "Secret Access Key" be specified directly in this file
             - "Access Key" - The access key to use when using STATIC credentials provider
             - "Secret Access Key" - The secret access key to use when using STATIC credentials provider
+            - "Endpoint URL" - An optional URL that overrides the default AWS S3 endpoint URL.
+                 Set this when using an AWS S3 API compatible service hosted at a different URL.
      -->
     <!--
     <extensionBundlePersistenceProvider>
@@ -84,6 +86,7 @@
         <property name="Credentials Provider">DEFAULT_CHAIN</property>
         <property name="Access Key"></property>
         <property name="Secret Access Key"></property>
+        <property name="Endpoint URL"></property>
     </extensionBundlePersistenceProvider>
     -->
 

--- a/nifi-registry-core/pom.xml
+++ b/nifi-registry-core/pom.xml
@@ -36,16 +36,16 @@
         <module>nifi-registry-runtime</module>
         <module>nifi-registry-security-api</module>
         <module>nifi-registry-security-utils</module>
-	<module>nifi-registry-framework</module>
+        <module>nifi-registry-framework</module>
         <module>nifi-registry-provider-api</module>
         <module>nifi-registry-web-api</module>
         <module>nifi-registry-web-ui</module>
         <module>nifi-registry-web-docs</module>
-	<module>nifi-registry-bootstrap</module>
+        <module>nifi-registry-bootstrap</module>
         <module>nifi-registry-docs</module>
-	<module>nifi-registry-client</module>
+        <module>nifi-registry-client</module>
         <module>nifi-registry-docker</module>
-	<module>nifi-registry-bundle-utils</module>
+        <module>nifi-registry-bundle-utils</module>
     </modules>
 
     <dependencyManagement>

--- a/nifi-registry-extensions/pom.xml
+++ b/nifi-registry-extensions/pom.xml
@@ -26,7 +26,7 @@
 
     <modules>
         <module>nifi-registry-ranger</module>
-	<module>nifi-registry-aws</module>
+        <module>nifi-registry-aws</module>
     </modules>
 
 


### PR DESCRIPTION
@bbende -

In reviewing apache/nifi-registry#169, I wanted to try out compatibility with S3-compatible services such as MinIO. This required an additional configuration property for the S3ClientBuilder to override the default S3 URL. I added that property and verified that this branch works with the minio docker image.

While I had the branch open, I also added the shell scripts necessary to configure the Extension Bundle Persistence Provider in the NiFi Registry docker image via environment variables. There is no automated way to test this yet as the Registry docker image is build from stable, release versions and not master, but I've created https://issues.apache.org/jira/browse/NIFIREG-252 for adding a dockermaven profile to our source code build.

Let me know if you agree with adding these two commit to your branch prior to merging  apache/nifi-registry#169, or if you would like me to make any changes.

Thanks!

